### PR TITLE
fix: Remove non-existent public directory from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN npm ci
 
 # Copy source files and configs
 COPY src/ ${LAMBDA_TASK_ROOT}/src/
-COPY public/ ${LAMBDA_TASK_ROOT}/public/
 COPY vite.config.ts tsconfig.json tailwind.config.js postcss.config.js components.json ${LAMBDA_TASK_ROOT}/
 
 # Build client and server


### PR DESCRIPTION
The public/ directory does not exist in the project, causing Docker build failures. This commit removes the COPY instruction for the public/ directory from the Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)