### PR TITLE
fix: Add missing ECR permissions for Docker push

### DIFF
--- a/.aws/cfn-repository.yml
+++ b/.aws/cfn-repository.yml
@@ -97,6 +97,8 @@ Resources:
               - Effect: Allow
                 Action:
                   - ecr:BatchCheckLayerAvailability
+                  - ecr:BatchGetImage
+                  - ecr:GetDownloadUrlForLayer
                   - ecr:InitiateLayerUpload
                   - ecr:UploadLayerPart
                   - ecr:CompleteLayerUpload


### PR DESCRIPTION
Add ecr:BatchGetImage and ecr:GetDownloadUrlForLayer permissions to the GHA role policy. These permissions are required for Docker to verify existing layers and optimize the push process.

This fixes the 403 Forbidden error when pushing images to ECR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)