### PR TITLE
LambdaLogGroupにDeletionPolicyを追加

### DIFF
--- a/.aws/cfn-service.yml
+++ b/.aws/cfn-service.yml
@@ -62,6 +62,7 @@ Resources:
   # CloudWatch Logs Log Group for Lambda Function
   LambdaLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Retain
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-fn
       RetentionInDays: !Ref LogRetentionInDays


### PR DESCRIPTION
This pull request introduces a configuration change to the CloudFormation template for Lambda log groups. The most important update is the addition of a `DeletionPolicy` to retain logs when the stack is deleted.

CloudFormation template improvements:

* Added `DeletionPolicy: Retain` to the `LambdaLogGroup` resource in `.aws/cfn-service.yml`, ensuring that log data is preserved even if the stack is deleted.